### PR TITLE
Fix share allocation for unknown payer

### DIFF
--- a/src/splitter_app/controllers.py
+++ b/src/splitter_app/controllers.py
@@ -67,10 +67,17 @@ class SplitterController:
           with the last ower absorbing any tiny rounding diff
         Guarantees that sum(shares.values()) == round(amount, 2).
         """
+        # Include the payer in the share map even if they are not listed in
+        # participants to avoid misallocation.
         shares = {p: 0.0 for p in participants}
-        n = len(participants)
+        if payer not in shares:
+            shares[payer] = 0.0
 
-        if n == 0:
+        n = len(shares)
+
+        # No owers: payer covers full amount
+        if n == 1:
+            shares[payer] = round(amount, 2)
             return shares
 
         # 1) Payer’s portion

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -74,6 +74,13 @@ def test_allocate_shares_rounding_dust():
     assert shares["B"] == pytest.approx(3.50)
     assert shares["C"] == pytest.approx(3.50)
 
+def test_allocate_shares_unknown_payer():
+    parts = ["A", "B"]
+    shares = SplitterController._allocate_shares(20.0, 0.5, "C", parts)
+    assert shares["A"] == pytest.approx(5.0)
+    assert shares["B"] == pytest.approx(5.0)
+    assert shares["C"] == pytest.approx(10.0)
+
 # --- Tests for serial-number generation ---
 
 def test_generate_serial():


### PR DESCRIPTION
## Summary
- handle payer not in participants when allocating shares
- add regression test for new behavior

## Testing
- `export QT_QPA_PLATFORM=offscreen && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ed766d808327ae3852b6a940c8ee