### PR TITLE
Fix conda activation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cd splitter_app
 
 ```bash
 conda env create -f environment.yaml
-conda activate splitter_app_env
+conda activate splitter_app
 ```
 
 3. Configure Google Drive API:


### PR DESCRIPTION
## Summary
- update activation command to use the environment name from `environment.yaml`
- clean up remaining references to the previous environment name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f62782b08327a4550b79095fd11c