### PR TITLE
Add signal emission test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,6 @@ import sys
 # assuming conftest.py lives in <repo_root>/tests
 SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 sys.path.insert(0, SRC)
+
+# Use the offscreen platform to avoid xcb plugin errors in headless CI
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,6 +1,6 @@
 import pytest
 from splitter_app.ui.main_window import MainWindow
-from PySide6.QtWidgets import QApplication, QMessageBox
+from PySide6.QtWidgets import QApplication, QMessageBox, QTableWidgetItem
 from PySide6.QtCore import QDate
 
 @pytest.fixture(scope="session")
@@ -55,3 +55,24 @@ def test_on_delete_clicked_no_selection_shows_warning(app, monkeypatch):
     assert calls, "Expected a warning to be shown"
     title, msg = calls[0]
     assert "No Entry Selected" in title
+
+def test_on_delete_clicked_emits_serial(app):
+    win = MainWindow(["A","B"], ["Cat"])
+    win.table.setRowCount(1)
+    serial = "42"
+    item = QTableWidgetItem(serial)
+    win.table.setItem(0, 0, item)
+
+    # avoid needing real selection handling
+    win.table.setCurrentCell(0, 0)
+    win.table.selectRow(0)
+    win.table.selectedItems = lambda: [item]
+
+    captured = {}
+    def catcher(sn):
+        captured['sn'] = sn
+
+    win.transaction_deleted.connect(catcher)
+    win._on_delete_clicked()
+
+    assert captured.get('sn') == serial


### PR DESCRIPTION
## Summary
- extend main window tests for delete action
- ensure the serial number is emitted when a row is selected
- configure Qt for offscreen mode so tests run headlessly

## Testing
- `pytest -q tests/test_main_window.py::test_on_delete_clicked_emits_serial`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877f632f3248327a6d84a896b36f3e3