### PR TITLE
Fix dynamic credentials path for Drive sync

### DIFF
--- a/src/splitter_app/services/drive.py
+++ b/src/splitter_app/services/drive.py
@@ -7,7 +7,10 @@ Handles existing file permission issues by removing or resetting permissions.
 import os
 from .google_api import upload_to_drive as _upload_to_drive, \
                          download_from_drive as _download_from_drive
-from splitter_app.config import LOCAL_CSV_PATH, DRIVE_FILE_ID, CREDENTIALS_FILE
+# Import the config module so we can read its values dynamically.  This allows
+# tests and the authentication flow to modify paths at runtime (e.g. when
+# `ensure_credentials` updates `config.CREDENTIALS_FILE`).
+from splitter_app import config
 
 __all__ = ["download_csv", "upload_csv"]
 
@@ -17,27 +20,31 @@ def download_csv():
     If a previous CSV exists, try to remove it first to avoid permission errors.
     """
     # Ensure target directory exists
-    os.makedirs(os.path.dirname(LOCAL_CSV_PATH), exist_ok=True)
+    os.makedirs(os.path.dirname(config.LOCAL_CSV_PATH), exist_ok=True)
 
     # If the file already exists, attempt to remove or reset permissions
-    if os.path.exists(LOCAL_CSV_PATH):
+    if os.path.exists(config.LOCAL_CSV_PATH):
         try:
-            os.chmod(LOCAL_CSV_PATH, 0o666)
-            os.remove(LOCAL_CSV_PATH)
+            os.chmod(config.LOCAL_CSV_PATH, 0o666)
+            os.remove(config.LOCAL_CSV_PATH)
         except PermissionError:
             raise PermissionError(
-                f"Cannot overwrite existing CSV at '{LOCAL_CSV_PATH}'.\n"
+                f"Cannot overwrite existing CSV at '{config.LOCAL_CSV_PATH}'.\n"
                 "Please close any programs that may be using it or adjust file permissions."
             )
 
     # Perform download
-    _download_from_drive(DRIVE_FILE_ID, LOCAL_CSV_PATH, CREDENTIALS_FILE)
+    _download_from_drive(
+        config.DRIVE_FILE_ID, config.LOCAL_CSV_PATH, config.CREDENTIALS_FILE
+    )
 
 
 def upload_csv():
     """
     Upload the local transactions CSV to Google Drive, replacing the existing file.
     """
-    if not os.path.exists(LOCAL_CSV_PATH):
-        raise FileNotFoundError(f"Local CSV not found: {LOCAL_CSV_PATH}")
-    _upload_to_drive(DRIVE_FILE_ID, LOCAL_CSV_PATH, CREDENTIALS_FILE)
+    if not os.path.exists(config.LOCAL_CSV_PATH):
+        raise FileNotFoundError(f"Local CSV not found: {config.LOCAL_CSV_PATH}")
+    _upload_to_drive(
+        config.DRIVE_FILE_ID, config.LOCAL_CSV_PATH, config.CREDENTIALS_FILE
+    )

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -8,10 +8,10 @@ def test_download_csv_success(tmp_path, monkeypatch):
     fake_id = "FAKEID"
     fake_cred = "FAKECRED"
     fake_path = tmp_path / "transactions.csv"
-    # override module constants
-    monkeypatch.setattr(drive_module, "LOCAL_CSV_PATH", str(fake_path))
-    monkeypatch.setattr(drive_module, "DRIVE_FILE_ID", fake_id)
-    monkeypatch.setattr(drive_module, "CREDENTIALS_FILE", fake_cred)
+    # override module config values
+    monkeypatch.setattr(drive_module.config, "LOCAL_CSV_PATH", str(fake_path))
+    monkeypatch.setattr(drive_module.config, "DRIVE_FILE_ID", fake_id)
+    monkeypatch.setattr(drive_module.config, "CREDENTIALS_FILE", fake_cred)
     called = {}
     def fake_download(file_id, out_path, cred_path):
         called['args'] = (file_id, out_path, cred_path)
@@ -23,7 +23,7 @@ def test_download_csv_permission_error(tmp_path, monkeypatch):
     # TC-G2: simulate permission error when removing existing file
     fake_path = tmp_path / "transactions.csv"
     fake_path.write_text("data")
-    monkeypatch.setattr(drive_module, "LOCAL_CSV_PATH", str(fake_path))
+    monkeypatch.setattr(drive_module.config, "LOCAL_CSV_PATH", str(fake_path))
     # make os.remove raise PermissionError
     monkeypatch.setattr(drive_module.os, "remove", lambda p: (_ for _ in ()).throw(PermissionError("locked")))
     with pytest.raises(PermissionError):
@@ -32,7 +32,7 @@ def test_download_csv_permission_error(tmp_path, monkeypatch):
 def test_upload_csv_file_not_found(tmp_path, monkeypatch):
     # TC-G3: upload when no local CSV should raise FileNotFoundError
     fake_path = tmp_path / "transactions.csv"
-    monkeypatch.setattr(drive_module, "LOCAL_CSV_PATH", str(fake_path))
+    monkeypatch.setattr(drive_module.config, "LOCAL_CSV_PATH", str(fake_path))
     with pytest.raises(FileNotFoundError):
         drive_module.upload_csv()
 
@@ -42,9 +42,9 @@ def test_upload_csv_success(tmp_path, monkeypatch):
     fake_path.write_text("data")
     fake_id = "FILEID"
     fake_cred = "CREDPATH"
-    monkeypatch.setattr(drive_module, "LOCAL_CSV_PATH", str(fake_path))
-    monkeypatch.setattr(drive_module, "DRIVE_FILE_ID", fake_id)
-    monkeypatch.setattr(drive_module, "CREDENTIALS_FILE", fake_cred)
+    monkeypatch.setattr(drive_module.config, "LOCAL_CSV_PATH", str(fake_path))
+    monkeypatch.setattr(drive_module.config, "DRIVE_FILE_ID", fake_id)
+    monkeypatch.setattr(drive_module.config, "CREDENTIALS_FILE", fake_cred)
     called = {}
     def fake_upload(file_id, local_path, cred_path):
         called['args'] = (file_id, local_path, cred_path)


### PR DESCRIPTION
## Summary
- ensure Drive service reads credential, file ID, and CSV paths from config at runtime so authentication updates are respected
- update tests to monkeypatch config values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689286989a408327887d6ce13ec70c3c