### PR TITLE
Fix OAuth token path to use user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd splitter_app
 2. Install dependencies using conda:
 
 ```bash
-conda env create -f environment.yaml
+conda env create -f environment.yml
 conda activate splitter_app
 ```
 
@@ -80,6 +80,30 @@ conda activate splitter_app
 
 ```bash
 python src/splitter_app/main.py
+```
+
+## Running tests
+
+Run tests from the repo root with pytest. Network calls are mocked and the Qt UI runs offscreen in tests, so Google credentials are not required.
+
+```bash
+# install dependencies if needed
+pip install -r requirements.txt
+
+# run all tests
+pytest -q
+
+# run a single file
+pytest tests/test_models.py -q
+
+# run a single test
+pytest tests/test_models.py::test_from_csv_row_valid -q
+
+# stop on first failure
+pytest -x
+
+# filter by substring
+pytest -k "download or theme" -q
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Contribution Splitter
+# Splitter App
 
 A modern desktop application built with Python and PySide6 for managing shared expenses among multiple participants. The app tracks transactions, splits costs, calculates balances, and synchronizes data with Google Drive, enabling real-time collaboration.
 

--- a/src/splitter_app/config.py
+++ b/src/splitter_app/config.py
@@ -16,14 +16,24 @@ from splitter_app.utils import resource_path
 SCOPES: list[str] = ["https://www.googleapis.com/auth/drive.file"]
 
 # path to your OAuth2 client-secrets JSON (downloaded from Google Cloud Console)
-CLIENT_SECRETS_FILE: str = resource_path("resources/credentials.json")
+# You can override this with the environment variable below to point to a
+# different client (e.g., when testing a new GCP project).
+ENV_CLIENT_SECRETS_VAR = "GOOGLE_CLIENT_SECRETS_FILE"
+_env_client_secrets = os.getenv(ENV_CLIENT_SECRETS_VAR)
+if _env_client_secrets:
+    CLIENT_SECRETS_FILE: str = str(Path(_env_client_secrets))
+else:
+    CLIENT_SECRETS_FILE: str = resource_path("resources/credentials.json")
+
 # --- Environment variable for external credentials ---
 # If set, this path overrides the default token path
 ENV_CREDENTIALS_VAR = "GOOGLE_TOKEN_PATH"
 
 # --- Google Drive Settings ---
 # The Drive file ID for the transactions CSV
-DRIVE_FILE_ID: str = "1UNCEKJkpZ0nLDauX4Z2S_p01e64Th_wV"
+# You can override this per environment/session using GOOGLE_DRIVE_FILE_ID
+ENV_DRIVE_FILE_ID_VAR = "GOOGLE_DRIVE_FILE_ID"
+DRIVE_FILE_ID: str = os.getenv(ENV_DRIVE_FILE_ID_VAR) or "1UNCEKJkpZ0nLDauX4Z2S_p01e64Th_wV"
 
 # Path to OAuth2 credentials JSON
 # Priority:

--- a/src/splitter_app/config.py
+++ b/src/splitter_app/config.py
@@ -18,7 +18,7 @@ SCOPES: list[str] = ["https://www.googleapis.com/auth/drive.file"]
 # path to your OAuth2 client-secrets JSON (downloaded from Google Cloud Console)
 CLIENT_SECRETS_FILE: str = resource_path("resources/credentials.json")
 # --- Environment variable for external credentials ---
-# If set, this path will be used instead of the bundled token.json
+# If set, this path overrides the default token path
 ENV_CREDENTIALS_VAR = "GOOGLE_TOKEN_PATH"
 
 # --- Google Drive Settings ---
@@ -29,16 +29,15 @@ DRIVE_FILE_ID: str = "1UNCEKJkpZ0nLDauX4Z2S_p01e64Th_wV"
 # Priority:
 # 1) Path from ENV_CREDENTIALS_VAR
 # 2) Default at ~/.config/splitter_app/token.json
-# 3) Bundled resources/token.json
 _env_token_path = os.getenv(ENV_CREDENTIALS_VAR)
 default_config_path = Path.home() / ".config" / "splitter_app" / "token.json"
 
-if _env_token_path and Path(_env_token_path).exists():
+if _env_token_path:
+    # Use the path from the environment variable, even if it doesn't yet exist
     CREDENTIALS_FILE: str = str(Path(_env_token_path))
-elif default_config_path.exists():
-    CREDENTIALS_FILE: str = str(default_config_path)
 else:
-    CREDENTIALS_FILE: str = resource_path("resources/token.json")
+    # Fall back to the standard config directory; the token will be created here
+    CREDENTIALS_FILE: str = str(default_config_path)
 
 # Local path where the transactions CSV is stored/loaded
 LOCAL_CSV_PATH: str = resource_path("transactions.csv")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-import os
 import importlib
 from pathlib import Path
 
@@ -6,24 +5,35 @@ import splitter_app.config as config
 
 
 def test_credentials_file_defaults_to_config_dir(tmp_path, monkeypatch):
-    """When no env var is set, credentials should live in ~/.config/splitter_app."""
-    orig_home = os.environ["HOME"]
-    monkeypatch.setenv("HOME", str(tmp_path))
+    """
+    When no env var is set, credentials should live in ~/.config/splitter_app/token.json.
+    We patch Path.home() directly for cross-platform reliability.
+    """
+    # Ensure the env override is absent
     monkeypatch.delenv("GOOGLE_TOKEN_PATH", raising=False)
+    # Force Path.home() to our temp dir
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
     importlib.reload(config)
+
     expected = tmp_path / ".config" / "splitter_app" / "token.json"
     assert config.CREDENTIALS_FILE == str(expected)
-    # restore module to original state
-    monkeypatch.setenv("HOME", orig_home)
+
+    # Optional: restore module to a clean state for other tests
     importlib.reload(config)
 
 
 def test_credentials_file_uses_env_path_even_if_missing(tmp_path, monkeypatch):
-    """Env var should override default even if the file doesn't exist yet."""
+    """
+    Env var should override the default even if the file doesn't exist yet.
+    """
     env_path = tmp_path / "custom" / "token.json"
     monkeypatch.setenv("GOOGLE_TOKEN_PATH", str(env_path))
+
     importlib.reload(config)
+
     assert config.CREDENTIALS_FILE == str(env_path)
-    # restore module to original state
+
+    # Cleanup: remove override and restore module
     monkeypatch.delenv("GOOGLE_TOKEN_PATH", raising=False)
     importlib.reload(config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+import os
+import importlib
+from pathlib import Path
+
+import splitter_app.config as config
+
+
+def test_credentials_file_defaults_to_config_dir(tmp_path, monkeypatch):
+    """When no env var is set, credentials should live in ~/.config/splitter_app."""
+    orig_home = os.environ["HOME"]
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("GOOGLE_TOKEN_PATH", raising=False)
+    importlib.reload(config)
+    expected = tmp_path / ".config" / "splitter_app" / "token.json"
+    assert config.CREDENTIALS_FILE == str(expected)
+    # restore module to original state
+    monkeypatch.setenv("HOME", orig_home)
+    importlib.reload(config)
+
+
+def test_credentials_file_uses_env_path_even_if_missing(tmp_path, monkeypatch):
+    """Env var should override default even if the file doesn't exist yet."""
+    env_path = tmp_path / "custom" / "token.json"
+    monkeypatch.setenv("GOOGLE_TOKEN_PATH", str(env_path))
+    importlib.reload(config)
+    assert config.CREDENTIALS_FILE == str(env_path)
+    # restore module to original state
+    monkeypatch.delenv("GOOGLE_TOKEN_PATH", raising=False)
+    importlib.reload(config)


### PR DESCRIPTION
## Summary
- default OAuth token path to `$HOME/.config/splitter_app/token.json` when env var not set
- honor `GOOGLE_TOKEN_PATH` even if file doesn't exist yet
- add tests for credential path selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68996c3228848327bcc6a46554bf019b