### PR TITLE
Restrict OAuth token file permissions

### DIFF
--- a/src/splitter_app/services/auth.py
+++ b/src/splitter_app/services/auth.py
@@ -40,10 +40,14 @@ def ensure_credentials() -> str:
             )
             creds = flow.run_local_server(port=0)
 
-        # ensure directory exists & save the token
+        # ensure directory exists & save the token with restricted permissions
         token_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(token_path, "w", encoding="utf-8") as f:
+        # create the file with mode 0o600 to avoid exposing credentials
+        fd = os.open(token_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(creds.to_json())
+        # in case the file already existed, force permissions to 600
+        os.chmod(token_path, 0o600)
 
     # 4) Monkey-patch config.CREDENTIALS_FILE so download/upload use the new token
     _config.CREDENTIALS_FILE = token_path_str

--- a/tests/test_auth_permissions.py
+++ b/tests/test_auth_permissions.py
@@ -1,0 +1,30 @@
+import os
+import stat
+from unittest import mock
+
+from splitter_app.services import auth
+
+
+def test_token_saved_with_strict_permissions(tmp_path, monkeypatch):
+    token_path = tmp_path / "token.json"
+    monkeypatch.setenv(auth.ENV_CREDENTIALS_VAR, str(token_path))
+
+    dummy_creds = mock.Mock()
+    dummy_creds.valid = True
+    dummy_creds.to_json.return_value = "{}"
+
+    def fake_from_file(path, scopes):
+        raise FileNotFoundError
+
+    def fake_flow_from_client_secrets_file(client_secrets_file, scopes):
+        flow = mock.Mock()
+        flow.run_local_server.return_value = dummy_creds
+        return flow
+
+    monkeypatch.setattr(auth.Credentials, "from_authorized_user_file", staticmethod(fake_from_file))
+    monkeypatch.setattr(auth.InstalledAppFlow, "from_client_secrets_file", staticmethod(fake_flow_from_client_secrets_file))
+
+    path = auth.ensure_credentials()
+    assert os.path.exists(path)
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == 0o600


### PR DESCRIPTION
## Summary
- Securely save OAuth token with strict 0o600 permissions
- Add test ensuring credentials file is created with restricted permissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1360162608327a1b7aa5cfe24dd3d