### PR TITLE
feat: add Google Sheets transaction reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ A modern desktop application built with Python and PySide6 for managing shared e
 - Clearly displays amounts owed and paid by each participant.
 - Summarizes total and group-specific balances for easy understanding.
 
-### Google Drive Sync
+### Cloud Sync
 
 - Stores data remotely in a CSV file on Google Drive for easy access and updates.
+- Optionally reads transactions directly from a Google Sheet, removing the need for a CSV download.
 - Automatically synchronizes transactions upon opening and closing the application.
 
 ### User-Friendly Interface
@@ -70,11 +71,11 @@ conda env create -f environment.yml
 conda activate splitter_app
 ```
 
-3. Configure Google Drive API:
+3. Configure Google Drive/Sheets API:
 
 - Download OAuth2 credentials from [Google Cloud Console](https://console.cloud.google.com/).
 - Save credentials JSON as `resources/credentials.json`.
-- Authorize the application upon first run.
+- Authorize the application upon first run. Ensure the Sheet and Drive file are shared with this account if used.
 
 4. Launch the app:
 

--- a/src/splitter_app/config.py
+++ b/src/splitter_app/config.py
@@ -13,7 +13,10 @@ from splitter_app.utils import resource_path
 
 
 # at the top, after your imports
-SCOPES: list[str] = ["https://www.googleapis.com/auth/drive"]
+SCOPES: list[str] = [
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+]
 
 # path to your OAuth2 client-secrets JSON (downloaded from Google Cloud Console)
 # You can override this with the environment variable below to point to a
@@ -34,6 +37,13 @@ ENV_CREDENTIALS_VAR = "GOOGLE_TOKEN_PATH"
 # You can override this per environment/session using GOOGLE_DRIVE_FILE_ID
 ENV_DRIVE_FILE_ID_VAR = "GOOGLE_DRIVE_FILE_ID"
 DRIVE_FILE_ID: str = os.getenv(ENV_DRIVE_FILE_ID_VAR) or "1UNCEKJkpZ0nLDauX4Z2S_p01e64Th_wV"
+
+# --- Google Sheets Settings ---
+# Optional spreadsheet ID and range for reading transactions directly from Sheets
+ENV_SHEETS_ID_VAR = "GOOGLE_SHEETS_ID"
+ENV_SHEETS_RANGE_VAR = "GOOGLE_SHEETS_RANGE"
+SHEETS_SPREADSHEET_ID: str = os.getenv(ENV_SHEETS_ID_VAR, "")
+SHEETS_RANGE: str = os.getenv(ENV_SHEETS_RANGE_VAR, "Sheet1!A:H")
 
 # Path to OAuth2 credentials JSON
 # Priority:

--- a/src/splitter_app/services/google_api.py
+++ b/src/splitter_app/services/google_api.py
@@ -77,3 +77,16 @@ def download_from_drive(file_id, output_path, credentials_path):
             if status:
                 print(f"Download progress: {int(status.progress() * 100)}%")
     print(f"Downloaded to {output_path}")
+
+
+def read_sheet(spreadsheet_id, range_name, credentials_path):
+    """Return values from a Google Sheet range."""
+    creds = Credentials.from_authorized_user_file(credentials_path)
+    service = build('sheets', 'v4', credentials=creds)
+    result = (
+        service.spreadsheets()
+        .values()
+        .get(spreadsheetId=spreadsheet_id, range=range_name)
+        .execute()
+    )
+    return result.get("values", [])

--- a/src/splitter_app/services/sheets.py
+++ b/src/splitter_app/services/sheets.py
@@ -1,0 +1,24 @@
+# src/splitter_app/services/sheets.py
+"""Utilities for reading transactions from Google Sheets."""
+from splitter_app import config
+from splitter_app.models import Transaction
+from .google_api import read_sheet as _read_sheet
+
+__all__ = ["load_transactions"]
+
+def load_transactions():
+    """Fetch transactions from the configured Google Sheet."""
+    values = _read_sheet(
+        config.SHEETS_SPREADSHEET_ID,
+        config.SHEETS_RANGE,
+        config.CREDENTIALS_FILE,
+    )
+    transactions: list[Transaction] = []
+    for row in values:
+        if len(row) < 8:
+            continue
+        try:
+            transactions.append(Transaction.from_csv_row(row))
+        except (ValueError, IndexError):
+            continue
+    return transactions

--- a/tests/test_sheets.py
+++ b/tests/test_sheets.py
@@ -1,0 +1,26 @@
+import splitter_app.services.sheets as sheets_module
+
+
+def test_load_transactions(monkeypatch):
+    fake_id = "SHEETID"
+    fake_range = "Sheet1!A:H"
+    fake_cred = "CREDPATH"
+    sample = [
+        ["A001", "Lunch", "Adrian", "2024-01-01", "general", "Food & Drinks", "0.5", "10.0"],
+        ["B002", "Taxi", "Vic", "2024-01-02", "general", "Travel", "1.0", "20.0"],
+    ]
+    monkeypatch.setattr(sheets_module.config, "SHEETS_SPREADSHEET_ID", fake_id)
+    monkeypatch.setattr(sheets_module.config, "SHEETS_RANGE", fake_range)
+    monkeypatch.setattr(sheets_module.config, "CREDENTIALS_FILE", fake_cred)
+
+    called = {}
+
+    def fake_read(sheet_id, rng, cred):
+        called["args"] = (sheet_id, rng, cred)
+        return sample
+
+    monkeypatch.setattr(sheets_module, "_read_sheet", fake_read)
+    txns = sheets_module.load_transactions()
+
+    assert called["args"] == (fake_id, fake_range, fake_cred)
+    assert [t.serial_number for t in txns] == ["A001", "B002"]


### PR DESCRIPTION
## Summary
- support reading transactions from Google Sheets using new config and service
- expose `read_sheet` helper in Google API module
- document optional Google Sheets workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c13a64e044832784cf9d47c5e43dfa