### PR TITLE
Prompt Drive access request when file not shared

### DIFF
--- a/src/splitter_app/main.py
+++ b/src/splitter_app/main.py
@@ -3,11 +3,18 @@
 import sys
 import os
 from PySide6.QtWidgets import QApplication, QMessageBox
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtCore import QUrl
 from splitter_app.ui.theme import apply_dark_fusion
 from splitter_app.ui.main_window import MainWindow
 from splitter_app.controllers import SplitterController
 from splitter_app.services.drive import download_csv, upload_csv
-from splitter_app.config import PARTICIPANTS, TRANSACTION_CATEGORIES, LOCAL_CSV_PATH
+from splitter_app.config import (
+    PARTICIPANTS,
+    TRANSACTION_CATEGORIES,
+    LOCAL_CSV_PATH,
+    DRIVE_FILE_ID,
+)
 from splitter_app.services.auth import ensure_credentials
 
 def main():
@@ -39,6 +46,17 @@ def main():
             str(e)
         )
         sys.exit(1)
+    except FileNotFoundError as e:
+        response = QMessageBox.question(
+            None,
+            "Request Access",
+            f"{e}\n\nRequest access to the Drive file?",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if response == QMessageBox.Yes:
+            url = QUrl(f"https://drive.google.com/file/d/{DRIVE_FILE_ID}/view")
+            QDesktopServices.openUrl(url)
+        # continue with whatever local data exists
     except Exception as e:
         QMessageBox.warning(
             None,
@@ -66,6 +84,16 @@ def main():
         if os.path.exists(LOCAL_CSV_PATH):
             try:
                 upload_csv()
+            except FileNotFoundError as e:
+                response = QMessageBox.question(
+                    None,
+                    "Request Access",
+                    f"{e}\n\nRequest access to the Drive file?",
+                    QMessageBox.Yes | QMessageBox.No,
+                )
+                if response == QMessageBox.Yes:
+                    url = QUrl(f"https://drive.google.com/file/d/{DRIVE_FILE_ID}/view")
+                    QDesktopServices.openUrl(url)
             except Exception as e:
                 QMessageBox.warning(
                     None,

--- a/tests/test_access_request.py
+++ b/tests/test_access_request.py
@@ -1,0 +1,68 @@
+import pytest
+
+
+def test_request_access_link_opened(monkeypatch):
+    import splitter_app.main as main_module
+
+    # Stub out application and UI setup
+    class DummyApp:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def exec(self):
+            return 0
+
+    monkeypatch.setattr(main_module, "QApplication", lambda *a, **k: DummyApp())
+    monkeypatch.setattr(main_module, "apply_dark_fusion", lambda app: None)
+
+    # Simulate credential and download behavior
+    monkeypatch.setattr(main_module, "ensure_credentials", lambda: "token")
+
+    def fake_download():
+        raise FileNotFoundError("not shared")
+
+    monkeypatch.setattr(main_module, "download_csv", fake_download)
+
+    # Avoid running real UI components
+    class DummyWin:
+        def show(self):
+            pass
+
+    monkeypatch.setattr(main_module, "MainWindow", lambda *a, **k: DummyWin())
+
+    class DummyController:
+        def __init__(self, *a, **k):
+            pass
+
+        def initialize(self):
+            pass
+
+    monkeypatch.setattr(main_module, "SplitterController", DummyController)
+
+    # Skip uploads and file existence checks
+    monkeypatch.setattr(main_module, "upload_csv", lambda: None)
+    monkeypatch.setattr(main_module.os.path, "exists", lambda p: False)
+
+    # Capture URL opening
+    opened = {}
+
+    def fake_open(url):
+        opened["url"] = url.toString()
+
+    monkeypatch.setattr(main_module.QDesktopServices, "openUrl", fake_open)
+
+    # Auto-accept request prompt
+    monkeypatch.setattr(
+        main_module.QMessageBox,
+        "question",
+        lambda *a, **k: main_module.QMessageBox.Yes,
+    )
+
+    # Suppress other message boxes
+    monkeypatch.setattr(main_module.QMessageBox, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(main_module.QMessageBox, "information", lambda *a, **k: None)
+
+    with pytest.raises(SystemExit):
+        main_module.main()
+
+    assert opened["url"].startswith("https://drive.google.com/file/d/")


### PR DESCRIPTION
## Summary
- Prompt users to request Drive file access when download or upload fails because the file isn't shared
- Open the file's Drive page to request access directly from the app
- Add regression test ensuring the request access link is opened

## Testing
- `pip install PySide6`
- `apt-get install -y libgl1`
- `apt-get install -y libxkbcommon-x11-0`
- `apt-get install -y libegl1`
- `pip install google-api-python-client`
- `pip install google-auth-oauthlib`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c13bcfb0208327a82f3e5e498d40ea