### PR TITLE
feat: refresh UI with minimalist theme

### DIFF
--- a/src/splitter_app/controllers.py
+++ b/src/splitter_app/controllers.py
@@ -155,7 +155,7 @@ class SplitterController:
                 else:
                     parts.append(f"{p}: ${bal:.2f}")
 
-            self.window.summary_label.setText(", ".join(parts))
+            self.window.summary_label.setText("\n".join(parts))
 
         # 3) Group summary (shares vs paid → net balance)
         from collections import defaultdict  # should already be at top of file
@@ -212,7 +212,10 @@ class SplitterController:
         formatted as “-$xx.xx” if negative, “$xx.xx” if ≥0.
         """
         table = self.window.group_summary_table
-        table.setRowCount(len(share_summary))
+        rows = len(share_summary)
+        table.setRowCount(rows + 1)
+
+        totals = {p: 0.0 for p in PARTICIPANTS}
 
         for row, (group, owed_map) in enumerate(share_summary.items()):
             table.setItem(row, 0, QTableWidgetItem(group))
@@ -220,6 +223,13 @@ class SplitterController:
                 owed = owed_map.get(p, 0.0)
                 paid = paid_summary[group].get(p, 0.0)
                 bal = paid - owed
-                # no space after minus; two decimals; positive shows with $
+                totals[p] += bal
                 text = f"-${abs(bal):.2f}" if bal < 0 else f"${bal:.2f}"
                 table.setItem(row, col, QTableWidgetItem(text))
+
+        total_row = rows
+        table.setItem(total_row, 0, QTableWidgetItem("Total"))
+        for col, p in enumerate(PARTICIPANTS, start=1):
+            bal = totals[p]
+            text = f"-${abs(bal):.2f}" if bal < 0 else f"${bal:.2f}"
+            table.setItem(total_row, col, QTableWidgetItem(text))

--- a/src/splitter_app/main.py
+++ b/src/splitter_app/main.py
@@ -3,7 +3,7 @@
 import sys
 import os
 from PySide6.QtWidgets import QApplication, QMessageBox
-from splitter_app.ui.theme import apply_dark_fusion
+from splitter_app.ui.theme import apply_muji_theme
 from splitter_app.ui.main_window import MainWindow
 from splitter_app.controllers import SplitterController
 from splitter_app.services.drive import download_csv, upload_csv
@@ -17,7 +17,7 @@ def main():
     """
     # 1) Create the QApplication early so we can show message boxes
     app = QApplication(sys.argv)
-    apply_dark_fusion(app)
+    apply_muji_theme(app)
 
     # 2) First-run: make sure we have a token.json, then sync down with Drive
     try:

--- a/src/splitter_app/ui/main_window.py
+++ b/src/splitter_app/ui/main_window.py
@@ -3,7 +3,8 @@
 from PySide6.QtWidgets import (
     QMainWindow, QWidget, QLabel, QLineEdit, QComboBox,
     QPushButton, QTableWidget, QTableWidgetItem, QGridLayout,
-    QDateEdit, QVBoxLayout, QMessageBox, QHeaderView, QDoubleSpinBox, QHBoxLayout
+    QDateEdit, QVBoxLayout, QMessageBox, QHeaderView, QDoubleSpinBox, QHBoxLayout,
+    QFrame
 )
 from PySide6.QtCore import Qt, QDate, Signal
 
@@ -35,6 +36,8 @@ class MainWindow(QMainWindow):
         container = QWidget()
         self.setCentralWidget(container)
         main_layout = QVBoxLayout(container)
+        main_layout.setContentsMargins(24, 24, 24, 24)
+        main_layout.setSpacing(18)
 
         # --- INPUT FORM ---
         form_layout = QGridLayout()
@@ -138,12 +141,18 @@ class MainWindow(QMainWindow):
         main_layout.addWidget(self.table)
 
         # --- SUMMARY & DELETE ---
-        summary_layout = QGridLayout()
+        summary_frame = QFrame()
+        summary_frame.setObjectName("summaryFrame")
+        summary_layout = QHBoxLayout(summary_frame)
+        summary_layout.setContentsMargins(12, 12, 12, 12)
         self.summary_label = QLabel("No transactions yet.")
-        summary_layout.addWidget(self.summary_label, 0, 0)
+        self.summary_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        self.summary_label.setWordWrap(True)
+        summary_layout.addWidget(self.summary_label)
+        summary_layout.addStretch()
         self.delete_button = QPushButton("Delete Entry")
-        summary_layout.addWidget(self.delete_button, 0, 1)
-        main_layout.addLayout(summary_layout)
+        summary_layout.addWidget(self.delete_button)
+        main_layout.addWidget(summary_frame)
 
         # --- GROUP SUMMARY TABLE ---
         self.group_summary_table = QTableWidget()

--- a/src/splitter_app/ui/theme.py
+++ b/src/splitter_app/ui/theme.py
@@ -34,3 +34,45 @@ def apply_dark_fusion(app: QApplication, icon_name: str = "wallet-icon.ico") -> 
     else:
         # Avoid crashing if the icon is missing; useful in testing/packaging
         print(f"Warning: icon '{icon_path}' not found; using default icon")
+
+
+def apply_muji_theme(app: QApplication, icon_name: str = "wallet-icon.ico") -> None:
+    """Apply a light, Muji-inspired minimalist palette and basic styling."""
+    app.setStyle("Fusion")
+
+    palette = QPalette()
+    palette.setColor(QPalette.ColorRole.Window, QColor("#f4f3f0"))
+    palette.setColor(QPalette.ColorRole.WindowText, QColor("#2e2e2e"))
+    palette.setColor(QPalette.ColorRole.Base, QColor("#ffffff"))
+    palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#fafafa"))
+    palette.setColor(QPalette.ColorRole.Text, QColor("#2e2e2e"))
+    palette.setColor(QPalette.ColorRole.Button, QColor("#e5e4e2"))
+    palette.setColor(QPalette.ColorRole.ButtonText, QColor("#2e2e2e"))
+    palette.setColor(QPalette.ColorRole.Highlight, QColor("#c6c5b9"))
+    palette.setColor(QPalette.ColorRole.HighlightedText, QColor("#2e2e2e"))
+    app.setPalette(palette)
+
+    app.setStyleSheet(
+        """
+        QTableWidget {
+            gridline-color: #d0d0d0;
+            alternate-background-color: #fafafa;
+        }
+        QHeaderView::section {
+            background-color: #f0f0f0;
+            padding: 4px;
+            border: 1px solid #d0d0d0;
+        }
+        QFrame#summaryFrame {
+            background-color: #ffffff;
+            border: 1px solid #d0d0d0;
+            border-radius: 6px;
+        }
+        """
+    )
+
+    icon_path = resource_path(f"resources/images/{icon_name}")
+    if os.path.exists(icon_path):
+        app.setWindowIcon(QIcon(icon_path))
+    else:
+        print(f"Warning: icon '{icon_path}' not found; using default icon")


### PR DESCRIPTION
## Summary
- add Muji-inspired light theme and apply on startup
- display multiline totals and aggregate row in group summary
- space out main window and frame summary area for clarity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c181247a808327ba51a61a9571fc09