### PR TITLE
Add group table sorting and dark mode toggle

### DIFF
--- a/src/splitter_app/ui/main_window.py
+++ b/src/splitter_app/ui/main_window.py
@@ -1,12 +1,27 @@
 # src/splitter_app/ui/main_window.py
 
 from PySide6.QtWidgets import (
-    QMainWindow, QWidget, QLabel, QLineEdit, QComboBox,
-    QPushButton, QTableWidget, QTableWidgetItem, QGridLayout,
-    QDateEdit, QVBoxLayout, QMessageBox, QHeaderView, QDoubleSpinBox, QHBoxLayout,
-    QFrame
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QLabel,
+    QLineEdit,
+    QComboBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QGridLayout,
+    QDateEdit,
+    QVBoxLayout,
+    QMessageBox,
+    QHeaderView,
+    QDoubleSpinBox,
+    QHBoxLayout,
+    QFrame,
 )
+from PySide6.QtGui import QAction
 from PySide6.QtCore import Qt, QDate, Signal
+from .theme import apply_dark_fusion, apply_muji_theme
 
 class MainWindow(QMainWindow):
     """
@@ -28,8 +43,21 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("Splitter App v2.0.2")
         self.setMinimumSize(800, 600)
 
+        self._create_menu()
         self._build_ui()
         self._connect_signals()
+
+    def _create_menu(self):
+        """Builds the menu bar with File/View/Edit and a dark mode toggle."""
+        menu_bar = self.menuBar()
+        menu_bar.addMenu("File")
+        view_menu = menu_bar.addMenu("View")
+        menu_bar.addMenu("Edit")
+
+        self.dark_mode_action = QAction("Dark Mode", self)
+        self.dark_mode_action.setCheckable(True)
+        self.dark_mode_action.toggled.connect(self._toggle_dark_mode)
+        view_menu.addAction(self.dark_mode_action)
 
     def _build_ui(self):
         # --- Central container & main layout ---
@@ -165,7 +193,7 @@ class MainWindow(QMainWindow):
         for col in range(self.group_summary_table.columnCount()):
             hdr2.setSectionResizeMode(col, QHeaderView.ResizeMode.Stretch)
         self.group_summary_table.setAlternatingRowColors(True)
-        self.group_summary_table.setSortingEnabled(False)
+        self.group_summary_table.setSortingEnabled(True)
         main_layout.addWidget(self.group_summary_table)
 
     def _connect_signals(self):
@@ -204,6 +232,14 @@ class MainWindow(QMainWindow):
         """Update the ower label whenever payer changes."""
         ower_frac = round(1.0 - payer_frac, 1)
         self.ower_label.setText(f"Ower: {ower_frac:.1f}")
+
+    def _toggle_dark_mode(self, checked: bool) -> None:
+        """Switch between light and dark themes based on menu action state."""
+        app = QApplication.instance()
+        if checked:
+            apply_dark_fusion(app)
+        else:
+            apply_muji_theme(app)
 
     # (Optionally, you can add methods like `set_transactions(...)`,
     #  `update_summary_text(...)`, `populate_group_summary(...)` here

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -76,3 +76,27 @@ def test_on_delete_clicked_emits_serial(app):
     win._on_delete_clicked()
 
     assert captured.get('sn') == serial
+
+
+def test_group_summary_table_sorting_enabled(app):
+    win = MainWindow(["A", "B"], ["Cat"])
+    assert win.group_summary_table.isSortingEnabled()
+
+
+def test_dark_mode_action_toggles_theme(app, monkeypatch):
+    win = MainWindow(["A", "B"], ["Cat"])
+
+    called = {"mode": None}
+    monkeypatch.setattr(
+        "splitter_app.ui.main_window.apply_dark_fusion",
+        lambda a: called.update(mode="dark"),
+    )
+    monkeypatch.setattr(
+        "splitter_app.ui.main_window.apply_muji_theme",
+        lambda a: called.update(mode="light"),
+    )
+
+    win.dark_mode_action.setChecked(True)
+    assert called["mode"] == "dark"
+    win.dark_mode_action.setChecked(False)
+    assert called["mode"] == "light"


### PR DESCRIPTION
## Summary
- enable sorting for the group summary table
- add menu bar with dark mode toggle
- test group sorting and dark mode toggling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c19f0345748327bac9e7125b916be8